### PR TITLE
Fixed for laravel 5.5 compatibility.

### DIFF
--- a/console/StorageClear.php
+++ b/console/StorageClear.php
@@ -20,7 +20,7 @@ class StorageClear extends Command
      * Execute the console command.
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // remove files without related register...
         $this->info(trans('genius.storageclear::lang.clear.seeking.files'));

--- a/console/StorageDump.php
+++ b/console/StorageDump.php
@@ -20,7 +20,7 @@ class StorageDump extends Command
      * Execute the console command.
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->call('storage:dump-project');
         $this->call('storage:dump-database');

--- a/console/StorageDumpDatabase.php
+++ b/console/StorageDumpDatabase.php
@@ -20,7 +20,7 @@ class StorageDumpDatabase extends Command
      * Execute the console command.
      * @return void
      */
-    public function fire()
+    public function handle()
     {
 
         $this->info(trans('genius.storageclear::lang.database.start'));

--- a/console/StorageDumpProject.php
+++ b/console/StorageDumpProject.php
@@ -20,7 +20,7 @@ class StorageDumpProject extends Command
      * Execute the console command.
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info(trans('genius.storageclear::lang.project.cleaning'));
 


### PR DESCRIPTION
I tested it on Laravel 5.5-dev as well as 5.1.46 (LTS)

Also i looked for Laravel 5.1 base Command class and it checks for handle method, so looks stable.

`$method = method_exists($this, 'handle') ? 'handle' : 'fire';`

Update plugin version is on your side :)